### PR TITLE
Add configuration for s3.topics.prefix

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -164,6 +164,9 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public static final String S3_PATH_STYLE_ACCESS_ENABLED_CONFIG = "s3.path.style.access.enabled";
   public static final boolean S3_PATH_STYLE_ACCESS_ENABLED_DEFAULT = true;
+  
+  public static final String S3_TOPICS_PREFIX_CONFIG = "s3.topics.prefix";
+  public static final String S3_TOPICS_PREFIX_DEFAULT = null;
 
   public static final String STORE_KAFKA_KEYS_CONFIG = "store.kafka.keys";
   public static final String STORE_KAFKA_HEADERS_CONFIG = "store.kafka.headers";
@@ -592,6 +595,22 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           ++orderInGroup,
           Width.SHORT,
           "Behavior for null-valued records"
+      );
+        
+      configDef.define(
+          S3_TOPICS_PREFIX_CONFIG,
+          Type.STRING,
+          S3_TOPICS_PREFIX_DEFAULT,
+          Importance.LOW,
+          "Prefix to the topic name that allows a Glue-compatible directory name."
+              + " E.g. when set to \"'topic'=\" the directory is named"
+              + " \"'topic'=S3_topic\" instead of just \"S3_topic\"."
+              +  "This will match the partitioning format"
+              + " \"'year'=YYYY/'month'=MM/'day'=dd/'hour'=HH\"."
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          "S3 topics prefix"
       );
     }
 


### PR DESCRIPTION
## Problem

When all topics written to S3 have the same root directory (that defaults to "topics") it is not possible change the actual topic name used within this.

When the intention is to set up AWS Glue to search all topics and partition them by topic name and date, this is not easily achieved when the topic directory does not have the tag needed for partitioning. For instance, "MSCK REPAIR TABLE" will fail since the folder name does not follow the convention of "<name>=<value>".

## Solution

Add a configuration setting to use a prefix when provided with the topic name. When a prefix is not defined, the topic name is output as it is now without this change.

When s3.topics.prefix is set to "topic=" the directory is named "topic=S3_topic" instead of just "S3_topic". This will match the partitioning format "'year'=YYYY/'month'=MM/'day'=dd/'hour'=HH".

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ X ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
